### PR TITLE
Added Logic to check existence of ConfigMaps for ChaosExperiments

### DIFF
--- a/pkg/webhook/appFilterCheck.go
+++ b/pkg/webhook/appFilterCheck.go
@@ -28,44 +28,20 @@ import (
 )
 
 func (wh *webhook) ValidateChaosExperimentsConfigMaps(chaosEngine *v1alpha1.ChaosEngine) error {
-	configMaps, err := wh.kubeClient.CoreV1().ConfigMaps(chaosEngine.Spec.Appinfo.Appns).List(metav1.ListOptions{
-		LabelSelector: chaosEngine.Spec.Appinfo.Applabel,
-	})
-	if err != nil {
-		return fmt.Errorf("unable to list ConfigMaps with matching labels, please check the following error: %v", err)
-	}
 	configMapErrors := make([]string, 0)
 	for _, experiment := range chaosEngine.Spec.Experiments {
-		if err = validateSingleExperimentConfigMaps(experiment, configMaps); err != nil {
-			configMapErrors = append(configMapErrors, err.Error())
+		for _, expectedConfigMap := range experiment.Spec.Components.ConfigMaps {
+			_, err := wh.kubeClient.CoreV1().ConfigMaps(chaosEngine.Spec.Appinfo.Appns).Get(expectedConfigMap.Name, metav1.GetOptions{})
+			if err != nil {
+				configMapErrors = append(configMapErrors,
+					fmt.Sprintf("Unable to find ConfigMap %s needed for ChaosExperiment %s, please check the following error: %v", expectedConfigMap.Name, experiment.Name, err))
+			}
 		}
 	}
 	if len(configMapErrors) == 0 {
 		return nil
 	}
 	return fmt.Errorf(strings.Join(configMapErrors, "\n"))
-}
-
-func validateSingleExperimentConfigMaps(chaosExperiment v1alpha1.ExperimentList, namespaceConfigMaps *corev1.ConfigMapList) error {
-	missingConfigMaps := make([]string, 0)
-	for _, expectedConfigMap := range chaosExperiment.Spec.Components.ConfigMaps {
-		if !isConfigMapExisting(expectedConfigMap.Name, namespaceConfigMaps) {
-			missingConfigMaps = append(missingConfigMaps, expectedConfigMap.Name)
-		}
-	}
-	if len(missingConfigMaps) > 0 {
-		return fmt.Errorf("Unable to find ConfigMaps %v needed for ChaosExperiment %s", missingConfigMaps, chaosExperiment.Name)
-	}
-	return nil
-}
-
-func isConfigMapExisting(toCheck string, existingConfigMaps *corev1.ConfigMapList) bool {
-	for _, existingConfigMap := range existingConfigMaps.Items {
-		if existingConfigMap.Name == toCheck {
-			return true
-		}
-	}
-	return false
 }
 
 func (wh *webhook) ValidateChaosTarget(chaosEngine *v1alpha1.ChaosEngine) error {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -197,7 +197,7 @@ func (wh *webhook) validateChaosEngineCreateUpdate(req *v1beta1.AdmissionRequest
 		}
 		return response
 	}
-	err = wh.CollectValidationErrors(&chaosEngine, wh.ValidateChaosTarget)
+	err = wh.CollectValidationErrors(&chaosEngine, wh.ValidateChaosTarget, wh.ValidateChaosExperimentsConfigMaps)
 	if err != nil {
 		klog.V(2).Infof("Validation Failed for ChaosEngine: %v", chaosEngine.Name)
 		response.Allowed = false


### PR DESCRIPTION
Signed-off-by: christopherfriedrich <christopher.friedrich@haw-hamburg.de>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Checks the existence of the referenced ConfigMaps in all ChaosExperiments and reports the missing ones

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #13 

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests